### PR TITLE
57 Handle Long File Names

### DIFF
--- a/front-end/src/components/FileStorage.js
+++ b/front-end/src/components/FileStorage.js
@@ -57,7 +57,7 @@ const CustomFileRenderer = (props) => {
     return (
         // Add in table row and then table data for each file, default styling will space it properly
         <tr {...connectDragSource} {...connectDropTarget} className={`file ${isSelected ? 'selected' : ''}`} onClick={handleSelectFile} >
-            <td className="name" style={{ paddingLeft: depthPadding }}>{file.name}</td>
+            <td className="name" style={{ paddingLeft: depthPadding, maxWidth: '250px' }}>{file.name}</td>
             <td className="size">{formatSize(file.size)}</td>
             <td className="modified">{file.modified ? file.modified : "-"}</td>
         </tr>

--- a/front-end/src/components/FileStorage.js
+++ b/front-end/src/components/FileStorage.js
@@ -57,7 +57,7 @@ const CustomFileRenderer = (props) => {
     return (
         // Add in table row and then table data for each file, default styling will space it properly
         <tr {...connectDragSource} {...connectDropTarget} className={`file ${isSelected ? 'selected' : ''}`} onClick={handleSelectFile} >
-            <td className="name" style={{ paddingLeft: depthPadding, maxWidth: '250px' }}>{file.name}</td>
+            <td className="name" style={{ paddingLeft: depthPadding }}>{file.name}</td>
             <td className="size">{formatSize(file.size)}</td>
             <td className="modified">{file.modified ? file.modified : "-"}</td>
         </tr>

--- a/front-end/src/styles/fileStorage.css
+++ b/front-end/src/styles/fileStorage.css
@@ -120,3 +120,7 @@ div.footer {
     color: white;
     cursor: pointer;
 }
+
+.name {
+    max-width: 250px
+}

--- a/front-end/src/styles/fileStorage.css
+++ b/front-end/src/styles/fileStorage.css
@@ -12,6 +12,7 @@
     margin: 0;
     font-family: 'Lato', sans-serif;
     font-weight: 200;
+    word-break: break-all;
 }
 
 .file.selected {


### PR DESCRIPTION
### Overview
Added additional formatting to prevent long file names from affecting size column and other row heights

### Rundown
- Added 'break-all' to file select so that all characters text-wrap
- Added maxWidth to rows so that size doesn't text wrap

### What is Implemented
- [x] Long file names don't cause other formatting to change