### PR TITLE
Delete endurance.bin

### DIFF
--- a/e2e/test-files/endurance.bin
+++ b/e2e/test-files/endurance.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b58cba36b4e8de2cac4bc70db081ef772697a6621ca82202b9fe1be5bfdda10f
-size 186514624


### PR DESCRIPTION
Removing the large file endurance.bin as it takes up a lot of space on Git LFS. This should allow us to use less bandwidth.