### PR TITLE
Fixed option disappearing behind container

### DIFF
--- a/front-end/src/components/ui/accordion/Accordion.module.scss
+++ b/front-end/src/components/ui/accordion/Accordion.module.scss
@@ -36,6 +36,7 @@
 
         &.expanded {
             padding-bottom: 2rem;
+            overflow: visible;
         }
 
         >* {


### PR DESCRIPTION
added overflow to be visible
<img width="670" height="1084" alt="image" src="https://github.com/user-attachments/assets/4ab5cbee-6aae-472c-82cf-37c3fa59dda5" />
